### PR TITLE
Client connection frame is sending wrong header for the version to be accepted.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -75,7 +75,7 @@ Client.prototype.connect = function(headers, callback){
     }
     
     headers = util.extend(headers, {
-        'accepted-version': '1.0,1.1,1.2'
+        'accept-version': '1.0,1.1,1.2'
     });
     
     var heartbeat = this.getHeartbeat();


### PR DESCRIPTION
According to the STOMP spec, the name of the header defining the accepted versions is 'accept-version' (http://stomp.github.io/stomp-specification-1.2.html#Connecting) but the code is currently sending 'accepted-version'.
