### PR TITLE
Fix channel pooling

### DIFF
--- a/lib/ChannelFactory.js
+++ b/lib/ChannelFactory.js
@@ -8,18 +8,18 @@
 var ChannelPool = require('./ChannelPool');
 var util        = require('util');
 
-function ChannelFactory(connectFailver) {
-  
-  ChannelPool.call(this, connectFailver, {
-    
+function ChannelFactory(connectFailover, options) {
+  var options = util.extend({
     minChannels:0,
     minFreeChannels: 0,
     
     maxChannels: Infinity,
+    freeExcessTimeout: 100
     
-    freeExcessTimeout: null
-  });
-  
+  }, options || {});
+
+
+  ChannelPool.call(this, connectFailover, options);
 }
 
 util.inherits(ChannelFactory, ChannelPool);

--- a/lib/ChannelPool.js
+++ b/lib/ChannelPool.js
@@ -37,6 +37,7 @@ function ChannelPool(connectFailover, options) {
   this._numChannels = 0;
   
   this._freeChannels = [];
+  this._freeExcessTimeout = options.freeExcessTimeout;
   this._freeExcessTimeouts = [];
   
   for (var i = 0; i < this._minChannels; i++) {


### PR DESCRIPTION
Hi,

Channels were not being reused, and a missing reference to the options in channelPool meant the freeExcessTimeout would always be essentially nextTick due to undefined.

Also allowed options to be passed to the pool via channelFactory.

Thanks
