### PR TITLE
Wrong 'this' destroyed when a server error is received

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -166,7 +166,7 @@ class Client extends Socket {
   }
 
   /*
-   * Send a message to the server. This method returns a Writable stream object 
+   * Send a message to the server. This method returns a Writable stream object
    * for sending the frame body content.
    */
   send(headers, options) {
@@ -215,7 +215,7 @@ class Client extends Socket {
       headers = {destination: headers};
     }
 
-    let id = headers.id !== undefined ? 
+    let id = headers.id !== undefined ?
       headers.id : this._nextSubcriptionId++;
 
     while (this._subscriptions[id] !== undefined) {
@@ -328,7 +328,7 @@ class Client extends Socket {
       }
     }).end(this._finishOutput.bind(this));
 
-    // Keep the transport output open until the receipt is processed just in 
+    // Keep the transport output open until the receipt is processed just in
     // case the transport is not configured to handle half-open connections.
 
     this._disconnecting = true;
@@ -432,9 +432,11 @@ function onError(frame) {
 
     const content = new BufferWritable(Buffer.alloc(ERROR_MAX_CONTENT_LENGTH));
 
+    const self = this;
+
     frame.on('end', function() {
       error.longMessage = content.getWrittenSlice().toString();
-      this.destroy(error);
+      self.destroy(error);
     });
 
     frame.pipe(content);


### PR DESCRIPTION
On receiving a server error frame an 'end' event handler is added to the incoming frame. Within this handler `this` refers to the incoming frame **not** the `Client` instance. The handler inadvertently calls `destroy` on the incoming frame and causes an uncaught exception.

`destroy` should be called on the `Client` instance to allow client code to attach an `on('error', ....)` handler.